### PR TITLE
fix: comparing columns with underscores

### DIFF
--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,6 +1,8 @@
 import os
 import unittest
+
 import pandas as pd
+
 from vdc.diff import _compare_df
 
 
@@ -31,6 +33,26 @@ class TestTableDiff(unittest.TestCase):
         result = _compare_df(prod_df, dev_df, "prod", "dev", "a")
         expected = pd.DataFrame(
             {"a": [3, 3], "b": [6.0, None], "result_name": ["prod", "dev"]}
+        ).set_index(["a", "result_name"])
+        self.assertTrue(result.equals(expected))
+
+    def test_compare_df_with_one_more_row_in_dev(self):
+        prod_df = pd.DataFrame({"a": [1, 2], "b": [4, 5]})
+        dev_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+        result = _compare_df(prod_df, dev_df, "prod", "dev", "a")
+        expected = pd.DataFrame(
+            {"a": [3, 3], "b": [None, 6.0], "result_name": ["prod", "dev"]}
+        ).set_index(["a", "result_name"])
+        self.assertTrue(result.equals(expected))
+
+    def test_compare_df_underscore_in_column_name(self):
+        prod_df = pd.DataFrame({"a": [1, 2, 3], "b_c": [4, 5, 6]})
+        dev_df = pd.DataFrame({"a": [1, 2, 3], "b_c": [4, 5, 7]})
+
+        result = _compare_df(prod_df, dev_df, "prod", "dev", "a")
+        expected = pd.DataFrame(
+            {"a": [3, 3], "b_c": [6.0, 7.0], "result_name": ["prod", "dev"]}
         ).set_index(["a", "result_name"])
         self.assertTrue(result.equals(expected))
 


### PR DESCRIPTION
If a table had columns with underscores, the comparison would fail when
using the diff command.
