### PR TITLE
feat: setup env if dbt installed but no dbt-files

### DIFF
--- a/vdc/open.py
+++ b/vdc/open.py
@@ -234,59 +234,71 @@ def setup_env():
         LOGGER.warning(
             "dbt-core or dbt-snowflake is not installed in environment. Skipping setup"
         )
-        continue_witouth_dbt = (
+        continue_without_dbt = (
             input("Are you sure you want to continue? Y/n: ").lower() != "n"
         )
-        if not continue_witouth_dbt:
+        if not continue_without_dbt:
             exit(0)
 
     if dbt_is_installed:
         LOGGER.info("Found dbt in environment")
         dbt_project_file = Path("dbt/dbt_project.yml")
-        _validate_file(dbt_project_file)
         profile_file = Path("dbt/profiles.yml")
-        _validate_file(profile_file)
+        dbt_files_exist = dbt_project_file.exists() and profile_file.exists()
 
-        default_dbt_targets = ["dev", "prod"]
-        dbt_targets = _get_dbt_targets(
-            project_file=dbt_project_file,
-            profile_file=profile_file,
-        )
-        _validate_dbt_targets(targets=dbt_targets, default_targets=default_dbt_targets)
-
-        echo("Select dbt target output")
-        selected_target = _selector(default_dbt_targets)
-        selected_dbt_target = dbt_targets[selected_target]
-        selected_database = selected_dbt_target["database"]
-        selected_role = selected_dbt_target["role"]
-        selected_user = selected_dbt_target["user"]
-
-        _validate_dbt_user(selected_user)
-
-        os.environ["DBT_TARGET"] = selected_target
-
-        LOGGER.info(f"Selected target username: {selected_user}")
-        LOGGER.info(f"Selected target database: {selected_database}")
-        LOGGER.info(f"Selected target role: {selected_role}")
-        LOGGER.info("\ndbt setup is done\n")
-
-        if dbt_is_installed and snowbird_is_installed and selected_target != "prod":
-            prod_target_database = dbt_targets["prod"]["database"]
-            replace_selected_database = (
-                input(
-                    f"\nReplace database '{selected_database}'\nwith a clone of database '{prod_target_database}'\nand give usage to role '{selected_role}'? y/N: "
-                ).lower()
-                == "y"
+        if not dbt_files_exist:
+            LOGGER.warning(
+                "dbt-core and dbt-snowflake are installed in environment, but could not find dbt_project.yml and/or profiles.yml.\nSkipping setup"
             )
-            if replace_selected_database:
-                echo(
-                    f"Replacing {selected_database} with a clone of {prod_target_database}"
+            continue_without_dbt = (
+                input("Are you sure you want to continue? Y/n: ").lower() != "n"
+            )
+            if not continue_without_dbt:
+                exit(0)
+
+        if dbt_files_exist:
+            default_dbt_targets = ["dev", "prod"]
+            dbt_targets = _get_dbt_targets(
+                project_file=dbt_project_file,
+                profile_file=profile_file,
+            )
+            _validate_dbt_targets(
+                targets=dbt_targets, default_targets=default_dbt_targets
+            )
+
+            echo("Select dbt target output")
+            selected_target = _selector(default_dbt_targets)
+            selected_dbt_target = dbt_targets[selected_target]
+            selected_database = selected_dbt_target["database"]
+            selected_role = selected_dbt_target["role"]
+            selected_user = selected_dbt_target["user"]
+
+            _validate_dbt_user(selected_user)
+
+            os.environ["DBT_TARGET"] = selected_target
+
+            LOGGER.info(f"Selected target username: {selected_user}")
+            LOGGER.info(f"Selected target database: {selected_database}")
+            LOGGER.info(f"Selected target role: {selected_role}")
+            LOGGER.info("\ndbt setup is done\n")
+
+            if dbt_is_installed and snowbird_is_installed and selected_target != "prod":
+                prod_target_database = dbt_targets["prod"]["database"]
+                replace_selected_database = (
+                    input(
+                        f"\nReplace database '{selected_database}'\nwith a clone of database '{prod_target_database}'\nand give usage to role '{selected_role}'? y/N: "
+                    ).lower()
+                    == "y"
                 )
-                _replace_dev_database(
-                    prod_target_database=prod_target_database,
-                    selected_database=selected_database,
-                    selected_role=selected_role,
-                )
+                if replace_selected_database:
+                    echo(
+                        f"Replacing {selected_database} with a clone of {prod_target_database}"
+                    )
+                    _replace_dev_database(
+                        prod_target_database=prod_target_database,
+                        selected_database=selected_database,
+                        selected_role=selected_role,
+                    )
 
     echo("Launching vscode")
     subprocess.run("source .venv/bin/activate && code .", shell=True)

--- a/vdc/open.py
+++ b/vdc/open.py
@@ -338,6 +338,7 @@ def setup_env():
 
             if dbt_is_installed and snowbird_is_installed and selected_target != "prod":
                 prod_target_database = dbt_targets["prod"]["database"]
+                _validate_dbt_database(prod_target_database)
                 replace_selected_database = (
                     input(
                         f"\nReplace database '{selected_database}'\nwith a clone of database '{prod_target_database}'\nand give usage to role '{selected_role}'? y/N: "


### PR DESCRIPTION
If dbt is installed in the environment but dbt_project.yml or profiles.yml is missing, the virtual environment should still be set up. This will ensure that is is possible to run the dbt init command.

If dbt_project.yml and profiles.yml do exist, there is now more specific error handling for missing keys and None values.